### PR TITLE
Release v0.3.1

### DIFF
--- a/src/assets/css/common.css
+++ b/src/assets/css/common.css
@@ -150,6 +150,14 @@ button.v-btn.emphasis {
   letter-spacing: -1px;
   color: #333;
 }
+/* 독서 기록/수정 폼의 text-field 요소*/
+.view.v-form .v-text-field .v-field {
+  border: 1px solid #bbb;
+  cursor: pointer;
+}
+.view.v-form .v-text-field .v-field .v-field__input input {
+  cursor: pointer;
+}
 
 /* -------------------- v-messages -------------------- */
 .v-messages .v-messages__message {
@@ -183,7 +191,7 @@ button.v-btn.emphasis {
   }
 
   /* -------------------- v-date-picker -------------------- */
-  .v-date-picker {
+  .v-date-picker.v-picker {
     display: block;
     width: auto;
   }

--- a/src/assets/css/components/contents.css
+++ b/src/assets/css/components/contents.css
@@ -19,6 +19,7 @@
 .view .v-sheet {
   background-color: transparent;
 }
+/* 도서 검색 결과 리스트 목록 간격 및 너비 설정 */
 .view .v-list {
   gap: 30px 60px;
   background-color: transparent;
@@ -90,7 +91,7 @@
 .view .v-card .v-card-title {
   display: -webkit-box;
   font-weight: 700;
-  font-size: 1.2em;
+  font-size: 1.17em;
   line-height: 1.4;
   letter-spacing: -1px;
   color: #333;
@@ -139,6 +140,7 @@
   /******************************
               LAYOUT
   ******************************/
+  /* 도서 검색 결과 리스트 목록 간격 및 너비 설정 */
   .view .v-list {
     gap: 20px 0;
   }

--- a/src/components/form/ReadingEndModifyForm.vue
+++ b/src/components/form/ReadingEndModifyForm.vue
@@ -1,7 +1,7 @@
 <template>
   <v-form
     ref="readingEndModifyForm"
-    class="view d-flex flex-column px-0 py-10 px-sm-8 px-lg-15 py-lg-5"
+    class="view d-flex flex-column px-0 py-3 px-sm-8 px-lg-15 py-lg-5"
     flat
   >
     <FormContentsLayout :book="myReadingEndItem" />

--- a/src/components/form/ReadingModifyForm.vue
+++ b/src/components/form/ReadingModifyForm.vue
@@ -1,7 +1,7 @@
 <template>
   <v-form
     ref="readingModifyForm"
-    class="view d-flex flex-column px-0 py-10 px-sm-8 px-lg-15 py-lg-5"
+    class="view d-flex flex-column px-0 py-3 px-sm-8 px-lg-15 py-lg-5"
     flat
   >
     <FormContentsLayout :book="myReadingItem" />

--- a/src/components/form/RecordForm.vue
+++ b/src/components/form/RecordForm.vue
@@ -1,7 +1,7 @@
 <template>
   <v-form
     ref="recordForm"
-    class="view d-flex flex-column px-0 py-10 px-sm-8 px-lg-15 py-lg-5"
+    class="view d-flex flex-column px-0 py-3 px-sm-8 px-lg-15 py-lg-5"
     flat
   >
     <FormContentsLayout :book="recordBook"/>

--- a/src/components/form/RecordForm.vue
+++ b/src/components/form/RecordForm.vue
@@ -49,14 +49,16 @@ const recordBook = ref({ ...selectBook.value, ...state.recordBookDefaultInfo });
 const cancelRecord = () => { router.back(); };
 
 // 기록하기
-const addRecord = async () => {
+const addRecord = async (currentUser) => {
   const { valid } = await recordForm.value.validate();
-  if (valid && recordBook.value.platform && recordBook.value.readingState) {
-    if (recordBook.value.readingState === '독서 중') addMyReading(recordBook.value);
-    else if (recordBook.value.readingState === '독서 완료') addMyReadingEnd(recordBook.value);
-    router.push({ name: 'home' });
+  if (currentUser) {
+    if (valid && recordBook.value.platform && recordBook.value.readingState) {
+      if (recordBook.value.readingState === '독서 중') addMyReading(recordBook.value);
+      else if (recordBook.value.readingState === '독서 완료') addMyReadingEnd(recordBook.value);
+      router.push({ name: 'home' });
+    }
+    else alert('기록에 필요한 정보를 정확하게 입력해주세요😢');
   }
-  else alert('기록에 필요한 정보를 정확하게 입력해주세요😢');
 };
 </script>
 

--- a/src/components/form/button/CloseButton.vue
+++ b/src/components/form/button/CloseButton.vue
@@ -1,6 +1,6 @@
 <template>
   <v-btn
-    class="flex-0-0 align-self-end order-first pa-0"
+    class="flex-0-0 align-self-end order-first mb-2 pa-0"
     size="large"
     flat
     @click="cancelRecord"

--- a/src/components/form/button/FormButtons.vue
+++ b/src/components/form/button/FormButtons.vue
@@ -35,7 +35,7 @@
       class="emphasis ma-0 ml-sm-5 px-8"
       size="large"
       flat
-      @click="addRecord"
+      @click="addRecord(currentUser)"
     >
       기록하기
       <NonLoginModal v-if="!currentUser" activator="parent" />

--- a/src/components/form/contents/BookDesc.vue
+++ b/src/components/form/contents/BookDesc.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mb-12">
     <span class="d-flex align-center mb-3">
-      <v-icon icon="mdi-book-edit-outline" class="mr-2" />
+      <v-icon class="mr-2" icon="mdi-book-edit" />
       책 소개
     </span>
     <p class="px-8 py-5">{{ book.description }}</p>

--- a/src/components/form/contents/BookDesc.vue
+++ b/src/components/form/contents/BookDesc.vue
@@ -19,6 +19,7 @@ p {
   border-radius: 8px;
   line-height: 1.5;
   letter-spacing: -1px;
+  border: 1px solid #bbb;
   color: #555;
   background-color: #f9f6ed;
 }

--- a/src/components/form/contents/BookInfo.vue
+++ b/src/components/form/contents/BookInfo.vue
@@ -4,7 +4,7 @@
     <v-img
       :src="book.cover"
       :alt="book.title"
-      class="flex-0-0 mr-sm-15 mb-8 mb-sm-0"
+      class="flex-0-0 mr-sm-12 mr-lg-15 mb-8 mb-sm-0"
       cover
     />
     <div class="d-flex flex-1-1 flex-column">
@@ -48,6 +48,15 @@ defineProps({
 }
 
 /******************************
+      max-width: 959px;
+******************************/
+@media all and (max-width: 959px) {
+  .v-card .v-card-title {
+    font-size: 1.25em;
+  }
+}
+
+/******************************
       max-width: 599px;
 ******************************/
 @media all and (max-width: 599px) {
@@ -60,9 +69,6 @@ defineProps({
   .v-card .v-img {
     width: 147px;
     height: 200px;
-  }
-  .v-card .v-card-title {
-    font-size: 1.25em;
   }
 }
 </style>

--- a/src/components/form/contents/BookPlatform.vue
+++ b/src/components/form/contents/BookPlatform.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mb-12">
     <span class="d-flex align-center mb-3">
-      <v-icon icon="mdi-book-edit-outline" class="mr-2" />
+      <v-icon class="mr-2" icon="mdi-book-edit" />
       플랫폼
     </span>
     <v-chip-group v-model="book.platform" class="pa-0" mandatory>

--- a/src/components/form/contents/Rating.vue
+++ b/src/components/form/contents/Rating.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mb-12">
     <span class="d-flex align-center mb-3">
-      <v-icon icon="mdi-book-edit-outline" class="mr-2" />
+      <v-icon class="mr-2" icon="mdi-book-edit" />
       나의 평점
       <em class="ml-1">(선택)</em>
     </span>

--- a/src/components/form/contents/ReadingDate.vue
+++ b/src/components/form/contents/ReadingDate.vue
@@ -6,7 +6,7 @@
         <v-icon icon="mdi-book-edit-outline" class="mr-2" />
         독서 시작일
       </span>
-      <v-text-field
+      <v-text-field class="qwer"
         :model-value="book.formattedReadingStartDate"
         :rules="startDateRule"
         placeholder="독서 시작일"

--- a/src/components/form/contents/ReadingDate.vue
+++ b/src/components/form/contents/ReadingDate.vue
@@ -3,18 +3,19 @@
     <!-- 독서 시작일 -->
     <div>
       <span class="d-flex align-center mb-3">
-        <v-icon icon="mdi-book-edit-outline" class="mr-2" />
+        <v-icon class="mr-2" icon="mdi-book-edit" />
         독서 시작일
       </span>
       <v-text-field class="qwer"
         :model-value="book.formattedReadingStartDate"
         :rules="startDateRule"
         placeholder="독서 시작일"
+        hint="독서를 시작한 날짜를 선택해주세요."
         variant="solo"
         prepend-inner-icon="mdi-calendar-month"
-        hide-details="auto"
         flat
         readonly
+        persistent-hint
       >
         <ReadingStartDateModal activator="parent" :book="book" />
       </v-text-field>
@@ -22,18 +23,19 @@
     <!-- 독서 완료일 -->
     <div v-if="book.readingState === '독서 완료'">
       <span class="d-flex align-center mb-3">
-        <v-icon icon="mdi-book-edit-outline" class="mr-2" />
+        <v-icon class="mr-2" icon="mdi-book-edit" />
         독서 완료일
       </span>
       <v-text-field
         :model-value="book.formattedReadingEndDate"
         :rules="endDateRule"
         placeholder="독서 완료일"
+        hint="독서를 완료한 날짜를 선택해주세요."
         variant="solo"
         prepend-inner-icon="mdi-calendar-month"
-        hide-details="auto"
         flat
         readonly
+        persistent-hint
       >
         <ReadingEndDateModal activator="parent" :book="book" />
       </v-text-field>

--- a/src/components/form/contents/ReadingPage.vue
+++ b/src/components/form/contents/ReadingPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <span class="d-flex align-center mb-3">
-      <v-icon icon="mdi-book-edit-outline" class="mr-2" />
+      <v-icon class="mr-2" icon="mdi-book-edit" />
       독서량
     </span>
     <div class="d-flex">

--- a/src/components/form/contents/ReadingState.vue
+++ b/src/components/form/contents/ReadingState.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mb-12">
     <span class="d-flex align-center mb-3">
-      <v-icon icon="mdi-book-edit-outline" class="mr-2" />
+      <v-icon class="mr-2" icon="mdi-book-edit" />
       독서 상태
     </span>
     <v-chip-group

--- a/src/components/form/contents/Review.vue
+++ b/src/components/form/contents/Review.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <span class="d-flex align-center mb-3">
-      <v-icon icon="mdi-book-edit-outline" class="mr-2" />
+      <v-icon class="mr-2" icon="mdi-book-edit" />
       나의 감상
       <em class="ml-1">(선택)</em>
     </span>

--- a/src/components/form/contents/Sentence.vue
+++ b/src/components/form/contents/Sentence.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mb-12">
     <span class="d-flex align-center mb-3">
-      <v-icon icon="mdi-book-edit-outline" class="mr-2" />
+      <v-icon class="mr-2" icon="mdi-book-edit" />
       나의 문장
       <em class="ml-1">(선택)</em>
     </span>

--- a/src/components/header/Header.vue
+++ b/src/components/header/Header.vue
@@ -6,7 +6,7 @@
     <!-- 로고 -->
     <v-app-bar-title class="ma-0">
       <h1>
-        <router-link :to="currentUser ? { name: 'home' } : { name: 'login' }">
+        <router-link :to="{ name: 'home' }">
           공책
           <span>Note, Book</span>
         </router-link>

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -6,11 +6,11 @@
     grow
   >
     <v-btn v-if="!currentUser" value="login" @click="navigateHome">
-      <v-icon>mdi-login</v-icon>
+      <v-icon icon="mdi-login" />
       로그인
     </v-btn>
     <v-btn v-else value="home" @click="navigateHome">
-      <v-icon>mdi-book-open-page-variant</v-icon>
+      <v-icon icon="mdi-book-open-page-variant" />
       나의 기록
     </v-btn>
   </v-bottom-navigation>

--- a/src/components/navigation/BottomNavigation.vue
+++ b/src/components/navigation/BottomNavigation.vue
@@ -1,0 +1,51 @@
+<template>
+  <v-bottom-navigation
+    v-model="selectNavigation"
+    class="hidden-sm-and-up rounded-t"
+    mandatory
+    grow
+  >
+    <v-btn v-if="!currentUser" value="login" @click="navigateHome">
+      <v-icon>mdi-login</v-icon>
+      로그인
+    </v-btn>
+    <v-btn v-else value="home" @click="navigateHome">
+      <v-icon>mdi-book-open-page-variant</v-icon>
+      나의 기록
+    </v-btn>
+  </v-bottom-navigation>
+</template>
+
+<script setup>
+import { ref, computed } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useMemberStore } from "@/stores/member";
+
+const selectNavigation = ref(0);
+
+const currentRoute = useRoute();
+const router = useRouter();
+
+const memberStore = useMemberStore();
+const currentUser = computed(() => memberStore.currentUser);
+
+const navigateHome = () => {
+  if (currentRoute.name !== "home") router.push({ name: "home" });
+};
+</script>
+
+<style scoped>
+.v-btn::v-deep .v-btn__content {
+  font-size: 1.4em;
+  font-family: LeeSeoyun, Roboto, "돋움", dotum, AppleGothic, sans-serif;
+}
+.v-btn::v-deep:hover .v-btn__overlay {
+  background-color: #bbb;
+}
+.v-btn--active {
+  color: #ca4f34;
+}
+.v-btn--active::v-deep .v-btn__overlay {
+  background-color: transparent;
+}
+</style>

--- a/src/components/search/Search.vue
+++ b/src/components/search/Search.vue
@@ -2,7 +2,7 @@
   <div class="inner mx-auto">
     <div class="sec-header mb-10">
       <h2 class="sec-title mb-5">
-        <router-link :to="currentUser ? { name: 'home' } : { name: 'login' }">공책</router-link>
+        <router-link :to="{ name: 'home' }">공책</router-link>
       </h2>
       <h3 class="sec-sub-title">Note, Book</h3>
       <span class="sec-desc">

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <Header />
-  <v-main class="pt-lg-0">
+  <v-main class="pt-lg-0 pb-sm-0">
     <v-container class="pa-0" fluid>
       <v-row class="ma-0">
         <v-col
@@ -20,6 +20,7 @@
       </v-row>
     </v-container>
   </v-main>
+  <BottomNavigation />
 </template>
 
 <script setup>
@@ -28,6 +29,7 @@ import '@/assets/css/components/contents.css';
 
 import Header from '@/components/header/Header.vue';
 import Search from '@/components/search/Search.vue';
+import BottomNavigation from '@/components/navigation/BottomNavigation.vue';
 </script>
 
 <style scoped>
@@ -66,7 +68,7 @@ import Search from '@/components/search/Search.vue';
     height: 400px;
   }
   .contents {
-    min-height: calc(100vh - 464px);
+    min-height: calc(100vh - 520px);
   }
 }
 </style>

--- a/src/stores/search.js
+++ b/src/stores/search.js
@@ -1,4 +1,5 @@
 import { reactive, computed } from 'vue';
+import { useRouter } from 'vue-router';
 import axios from 'axios';
 import { defineStore } from 'pinia';
 
@@ -6,6 +7,8 @@ export const useSearchStore = defineStore('search', () => {
   const ttbKey = import.meta.env.VITE_ALADIN_APP_KEY;
   const baseURL = `/api/ItemSearch.aspx?ttbkey=${ttbKey}&MaxResults=40&SearchTarget=Book&output=JS&Cover=Big&Version=20131101&Querytype=`;
   const detailBaseURL = `/api/ItemLookUp.aspx?ttbkey=${ttbKey}&itemIdType=ISBN13&output=JS&Cover=Big&Version=20131101&ItemId=`;
+
+  const router = useRouter();
 
   const state = reactive({
     isLoading: false,
@@ -79,7 +82,9 @@ export const useSearchStore = defineStore('search', () => {
       state.searchBookList.push(searchBookListGroup);
     }
     catch (error) {
-      alert(`도서 상세정보 검색 중 서버 오류가 발생했습니다. 새로고침 후 다시 시도해주세요.`);
+      alert(`도서 상세정보 검색 중 서버 오류가 발생했습니다😥 다시 시도해주세요.`);
+      await router.push({ name: 'home' });
+      router.go(0);
     }
   };
 

--- a/src/stores/search.js
+++ b/src/stores/search.js
@@ -23,7 +23,7 @@ export const useSearchStore = defineStore('search', () => {
     state.isLoading = true;
     state.searchBookList = []; // 저장된 이전 목록 초기화
     await searchBookBase(searchWord);
-    await searchBookDetail(state.searchResults[0]);
+    if (state.searchResults[0]) await searchBookDetail(state.searchResults[0]); // 검색 결과가 있는 경우만 상세정보 검색
     state.isLoading = false;
   };
 
@@ -80,9 +80,6 @@ export const useSearchStore = defineStore('search', () => {
     }
     catch (error) {
       alert(`도서 상세정보 검색 중 서버 오류가 발생했습니다. 새로고침 후 다시 시도해주세요.`);
-      console.log('도서 상세정보 검색 중 다음 오류가 발생했습니다.');
-      if (error instanceof Error) console.log(error.message);
-      else console.log(error);
     }
   };
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,7 +3,14 @@
     <h2 class="sec-title mb-4">나의 기록</h2>
   </div>
   <v-tabs v-model="state.selectTab" class="flex-0-0">
-    <v-tab v-for="tab in state.tabs" :key="tab.id" :value="tab.id" class="emphasis">{{ tab.label }}</v-tab>
+    <v-tab
+      v-for="tab in state.tabs"
+      :key="tab.id"
+      :value="tab.id"
+      class="emphasis"
+    >
+      {{ tab.label }}
+    </v-tab>
   </v-tabs>
   <keep-alive>
     <component :is="state.selectTab === 'MyReading' ? MyReading : MyReadingEnd" />
@@ -18,7 +25,7 @@ import MyReadingEnd from '@/components/tab/MyReadingEnd.vue';
 const state = reactive({
   tabs: [
     { id: 'MyReading', label: '독서 중' },
-    { id: 'MyReadingEnd', label: '독서 완료' }
+    { id: 'MyReadingEnd', label: '독서 완료' },
   ],
   selectTab: 'MyReading',
 });

--- a/src/views/SearchResult.vue
+++ b/src/views/SearchResult.vue
@@ -7,7 +7,7 @@
       </h2>
       <p class="sec-desc mb-3">최대 200권까지 검색할 수 있어요 🔎</p>
       <v-btn
-        class="align-self-end"
+        class="d-none d-sm-flex align-self-end"
         variant="outlined"
         @click="router.push(currentUser ? { name: 'home' } : { name: 'login' })"
       >

--- a/src/views/SearchResult.vue
+++ b/src/views/SearchResult.vue
@@ -9,7 +9,7 @@
       <v-btn
         class="d-none d-sm-flex align-self-end"
         variant="outlined"
-        @click="router.push(currentUser ? { name: 'home' } : { name: 'login' })"
+        @click="router.push({ name: 'home' })"
       >
         홈으로 이동
       </v-btn>
@@ -66,19 +66,16 @@
 <script setup>
 import { computed } from 'vue';
 import { useRouter } from 'vue-router';
-import { useMemberStore } from '@/stores/member';
 import { useSearchStore } from '@/stores/search';
 import Loading from '@/components/loading/Loading.vue';
 import SearchResultBook from '@/components/card/SearchResultBook.vue';
 
 const router = useRouter();
 
-const memberStore = useMemberStore();
 const searchStore = useSearchStore();
 const { state, searchBookMore } = searchStore;
 const isLoading = computed(() => searchStore.isLoading);
 const searchBookList = computed(() => searchStore.searchBookList);
-const currentUser = computed(() => memberStore.currentUser);
 
 // 도서 검색 결과 총개수
 const searchResultsNumber = () => {


### PR DESCRIPTION
### Features
- 모바일 화면에서 보이는 하단 네비게이션 추가

### Fixes
- 검색 결과가 있는 경우에만 도서 상세정보 검색을 실행하도록 함수 수정
- 비로그인 사용자의 독서 기록 요청 시, 폼 유효성 검사를 진행하지 않고 바로 로그인 유도 모달창을 렌더링
- 검색 시 서버 오류가 발생하면 router를 통해 home으로 이동 후 새로고침
- 모바일 화면에서 독서 시작/완료일 선택 모달창이 잘리는 이슈 해결

### Others
- 도서 제목 글자 크기 조정
- 검색 결과 페이지의 홈으로 이동하는 버튼을 모바일 화면에서 숨김 처리
- 독서 기록/수정 폼의 상하 padding 조정, 닫기 버튼과 콘텐츠 간 여백 조정, 항목 아이콘 변경
- 독서 기록/수정 폼의 입력 필드에 border style 적용, 독서 시작/완료일 입력 필드에 힌트 추가 및 커서를 포인터로 변경
- 사용자의 로그인 여부에 따른 route 이동 코드 간소화
- 가독성 향상을 위한 코드 스타일 정리